### PR TITLE
Use "wx" flags when creating file

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -127,7 +127,7 @@ export class WriteStream extends fs.WriteStream {
       );
 
       // create the file
-      fs.open(this.path, this.flags, this.mode, (error, fd) => {
+      fs.open(this.path, "wx", this.mode, (error, fd) => {
         if (error) {
           this.destroy(error);
           return;


### PR DESCRIPTION
The default value of flags is "w", which will overwrite files and follow symlinks. This lib should use "wx" to throw an error if the path exists.