### PR TITLE
fix: refactor to node streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "test:mjs": "if-ver -lt 12 || exit 0; node --experimental-modules --no-warnings lib/test | tap-mocha-reporter classic",
     "test:js": "node lib/test | tap-mocha-reporter classic",
     "prepublishOnly": "npm test"
+  },
+  "dependencies": {
+    "readable-stream": "^3.4.0"
   }
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -145,7 +145,7 @@ export class WriteStream extends Writable {
     }
 
     // Wait until all read streams have terminated before destroying this.
-    this._destroyPending = er => {
+    this._destroyPending = () => {
       process.removeListener("exit", this._cleanupSync);
       process.removeListener("SIGINT", this._cleanupSync);
 
@@ -159,18 +159,14 @@ export class WriteStream extends Writable {
         });
       };
 
-      if (typeof this.fd === "number") {
+      if (typeof this.fd === "number")
         fs.close(this.fd, closeError => {
           // An error here probably means the fd was already closed, but we can
           // still try to unlink the file.
 
           unlink(closeError || error);
         });
-
-        return;
-      } else callback(error);
-
-      unlink(er);
+      else callback(error);
     };
 
     // All read streams have terminated, so we can destroy this.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { Readable, Writable } from "stream";
+import { Readable, Writable } from "readable-stream";
 
 export class ReadAfterDestroyedError extends Error {}
 

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -299,11 +299,6 @@ const withChunkSize = size =>
         true,
         "should mark read stream as destroyed"
       );
-      t.type(
-        capacitor1Stream1.error,
-        Error,
-        "should store an error on read stream"
-      );
       t.strictSame(
         capacitor1._readStreams.size,
         1,
@@ -316,15 +311,11 @@ const withChunkSize = size =>
       capacitor1.destroy(null);
 
       t.strictSame(
-        capacitor1.destroyed,
+        capacitor1.closed,
         false,
         "should not destroy while read streams exist"
       );
-      t.strictSame(
-        capacitor1._destroyPending,
-        true,
-        "should mark for future destruction"
-      );
+      t.true(capacitor1._destroyPending, "should mark for future destruction");
       t.end();
     });
 
@@ -342,11 +333,6 @@ const withChunkSize = size =>
         capacitor1Stream3.destroyed,
         true,
         "should mark read stream as destroyed"
-      );
-      t.strictSame(
-        capacitor1Stream3.error,
-        null,
-        "should not store an error on read stream"
       );
       t.strictSame(
         capacitor1._readStreams.size,
@@ -392,37 +378,20 @@ const withChunkSize = size =>
     await capacitor2ReadStream1Destroyed;
 
     await t.test("propagates errors to attached read streams", async t => {
-      capacitor2.destroy();
-      await new Promise(resolve => setImmediate(resolve));
-      t.strictSame(
-        capacitor2Stream2.destroyed,
-        false,
-        "should not immediately mark attached read streams as destroyed"
-      );
-
+      capacitor2Stream2.on("error", () => {});
+      capacitor2.on("error", () => {});
       capacitor2.destroy(new Error("test"));
       await capacitor2Destroyed;
 
-      t.type(capacitor2.error, Error, "should store an error on capacitor");
       t.strictSame(
         capacitor2.destroyed,
         true,
         "should mark capacitor as destroyed"
       );
-      t.type(
-        capacitor2Stream2.error,
-        Error,
-        "should store an error on attached read streams"
-      );
       t.strictSame(
         capacitor2Stream2.destroyed,
         true,
         "should mark attached read streams as destroyed"
-      );
-      t.strictSame(
-        capacitor2Stream1.error,
-        null,
-        "should not store an error on detached read streams"
       );
     });
   });


### PR DESCRIPTION
Refactors module into node streams. There are some rules that should be followed to maintain compatibility with node streams:

- Don't override `destroy()`
- Don't override `open()` (it's deprecated)

This fixes breakage in Node 13 https://github.com/nodejs/node/issues/30110.

This is potentially breaking.

Fixes a bug where the capacitor could be destroyed before *all* readables have been destroyed.

Re-use same fd between write and read.

Slightly slower read since it doesn't re-use the pooling logic from `ReadStream`.