### PR TITLE
Drop node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
   - "node"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,8 @@
 - Add `WriteStream.release` replacing the functionality of an error-free `WriteStream.destroy()`
 - **BREAKING:** Change `WriteStream.destroy()` to immediately destroy attached `ReadStream`s even without an error.
 - **BREAKING:** Reluctantly remove exported `.mjs` files now that we have an external commonjs dependency and are still missing clear interop guidance from node.
+
+## 5.0.0
+
+- Remove dependency on `readable-stream` to expose new (but internally unused) features of streams in node v13.
+- **BREAKING:** Remove support for node v8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,19 @@
 
 ## 2.0.0
 
-- Updated dependencies.
+- Update dependencies.
 - Add tests for special stream scenarios.
 - **BREAKING:** Remove special handling of terminating events, see [jaydenseric/graphql-upload#131](https://github.com/jaydenseric/graphql-upload/issues/131)
 
 ### 2.0.1
 
-- Updated dependencies.
+- Update dependencies.
 - Move configs out of package.json
 - Use `wx` file flag instead of default `w` (thanks to @mattbretl via #8)
 
 ### 2.0.2
 
-- Updated dev dependencies.
+- Update dev dependencies.
 - Fix mjs structure to work with node v12.
 - Fix a bug that would pause consumption of read streams until completion. (thanks to @Nikosmonaut's investigation in #9).
 
@@ -44,7 +44,7 @@
 
 ## 3.0.0
 
-- Updated dev dependencies.
+- Update dev dependencies.
 - Add support for Node.js v13 by no longer extending `ReadStream` and `WriteStream` from node's `fs` library.
 - Specify `0o600` for buffer file permissions instead of node's default `0o666`
 - **BREAKING:** Remove several undocumented properties that existed for consistency with the extended classes.
@@ -59,5 +59,6 @@
 
 ## 5.0.0
 
+- Update dev dependencies.
 - Remove dependency on `readable-stream` to expose new (but internally unused) features of streams in node v13.
 - **BREAKING:** Remove support for node v8.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build status](https://travis-ci.org/mike-marcacci/fs-capacitor.svg?branch=master)](https://travis-ci.org/mike-marcacci/fs-capacitor) [![Current version](https://badgen.net/npm/v/fs-capacitor)](https://npm.im/fs-capacitor) ![Supported Node.js versions](https://badgen.net/npm/node/fs-capacitor)
 
+**If you need to run fs-capacitor on node version 8, use fs-capacitor version 4 which will continue to be supported through node v8's LTS end-of-life, which is January 1, 2020.**
+
 # FS Capacitor
 
 FS Capacitor is a filesystem buffer for finite node streams. It supports simultaneous read/write, and can be used to create multiple independent readable streams, each starting at the beginning of the buffer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-capacitor",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Filesystem-buffered, passthrough stream that buffers indefinitely rather than propagate backpressure from downstream consumers.",
   "license": "MIT",
   "author": {
@@ -22,9 +22,9 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": ">=8.5"
+    "node": ">=10"
   },
-  "browserslist": "node >= 8.5",
+  "browserslist": "node >= 10",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.3.2",
     "@typescript-eslint/parser": "^2.3.2",
@@ -46,8 +46,5 @@
     "prepare": "yarn build",
     "prepublishOnly": "yarn install && yarn lint && yarn build && yarn test"
   },
-  "dependencies": {
-    "@types/readable-stream": "^2.3.5",
-    "readable-stream": "^3.4.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
   },
   "browserslist": "node >= 10",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.3.2",
-    "@typescript-eslint/parser": "^2.3.2",
+    "@typescript-eslint/eslint-plugin": "^2.7.0",
+    "@typescript-eslint/parser": "^2.7.0",
     "ava": "^2.4.0",
     "eslint": "^6.5.1",
-    "eslint-config-prettier": "^6.3.0",
+    "eslint-config-prettier": "^6.6.0",
     "eslint-plugin-prettier": "^3.1.1",
     "nodemon": "^1.19.3",
-    "prettier": "^1.18.2",
-    "typescript": "^3.6.3"
+    "prettier": "^1.19.1",
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "format": "prettier --list-different --write '**/*.{json,yml,md,ts}'",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import stream from "stream";
 import test from "ava";
 import { ReadAfterDestroyedError, WriteStream } from "./index";
-import { Readable } from "readable-stream";
+import { Readable } from "stream";
 
 process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
@@ -338,7 +338,7 @@ function withChunkSize(size: number): void {
     // Make sure complete data is sent to a read stream.
     const result2 = await streamToString(capacitor1Stream2);
     t.is(
-      capacitor1Stream2._readableState.ended,
+      (capacitor1Stream2 as any)._readableState.ended,
       true,
       "should mark read stream as ended"
     );
@@ -346,7 +346,7 @@ function withChunkSize(size: number): void {
 
     const result4 = await streamToString(capacitor1Stream4);
     t.is(
-      capacitor1Stream4._readableState.ended,
+      (capacitor1Stream4 as any)._readableState.ended,
       true,
       "should mark read stream as ended"
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { Readable, Writable } from "readable-stream";
+import { Readable, Writable } from "stream";
 
 function checkSignalListeners(): void {
   if (!process.listeners("SIGINT").length)
@@ -70,7 +70,11 @@ export class ReadStream extends Readable {
 
         // If there were no more bytes to read and the write stream is finished,
         // than this stream has reached the end.
-        if (this._writeStream._writableState.finished) {
+        if (
+          ((this._writeStream as any) as {
+            _writableState: { finished: boolean };
+          })._writableState.finished
+        ) {
           this.push(null);
           return;
         }


### PR DESCRIPTION
To enable new stream features from node 13 on the created streams, we will want to use the native library. This requires dropping support for node version 8, which is _almost_ at its end-of-life.

I will continue to support `fs-capacitor` version 4 (which has an identical API to version 5) through the end of the year.