### PR TITLE
Use a single exit listener

### DIFF
--- a/src/test/deletion.ts
+++ b/src/test/deletion.ts
@@ -1,0 +1,26 @@
+import { WriteStream } from "../index";
+
+const capacitor = new WriteStream();
+
+capacitor.once("ready", () => {
+  if (!process.send) {
+    throw new Error("Must be called in child process");
+  }
+
+  process.send(
+    {
+      path: capacitor["_path"],
+    },
+    (err: Error | null) => {
+      if (err) {
+        throw err;
+      }
+    }
+  );
+});
+
+process.on("message", (msg) => {
+  if (msg.exit) {
+    process.exit();
+  }
+});


### PR DESCRIPTION
Instead of registering a `process.exit` listener for _each_ instance of `WriteStream`, register a single listener plus a global set of cleanup functions to call. On exit, call all the saved cleanup functions.

Inspired by https://github.com/raszi/node-tmp
Fixes #30