### PR TITLE
Proxy process.on("exit") to avoid MaxListenersExceededWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,4 @@
 
 - Upgrade dependencies.
 - **BREAKING:** Drop support for node 13.
+- Work around node's MaxListenersExceededWarning (#30 via #42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,4 +95,4 @@
 
 - Upgrade dependencies.
 - **BREAKING:** Drop support for node 13.
-- Work around node's MaxListenersExceededWarning (#30 via #42)
+- Prevent Node.js max listeners exceeded warnings if many `fs-capacitor` `ReadStream` instances are created at the same time, fixing [#30](https://github.com/mike-marcacci/fs-capacitor/issues/30) via [#42](https://github.com/mike-marcacci/fs-capacitor/pull/42).

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,13 +75,13 @@ export class ReadStream extends Readable {
 
         // Otherwise, wait for the write stream to add more data or finish.
         const retry = (): void => {
-          this._writeStream.removeListener("finish", retry);
-          this._writeStream.removeListener("write", retry);
+          this._writeStream.off("finish", retry);
+          this._writeStream.off("write", retry);
           this._read(n);
         };
 
-        this._writeStream.addListener("finish", retry);
-        this._writeStream.addListener("write", retry);
+        this._writeStream.on("finish", retry);
+        this._writeStream.on("write", retry);
       }
     );
   }
@@ -242,7 +242,7 @@ export class WriteStream extends Writable {
     this._readStreams.add(readStream);
 
     const remove = (): void => {
-      readStream.removeListener("close", remove);
+      readStream.off("close", remove);
       this._readStreams.delete(readStream);
 
       if (this._released && this._readStreams.size === 0) {
@@ -250,7 +250,7 @@ export class WriteStream extends Writable {
       }
     };
 
-    readStream.addListener("close", remove);
+    readStream.on("close", remove);
 
     return readStream;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export class WriteStream extends Writable {
         }
 
         // Cleanup when the process exits or is killed.
-        processExitProxy.addListener("exit", this._cleanupSync);
+        processExitProxy.once("exit", this._cleanupSync);
 
         this._fd = fd;
         this.emit("ready");

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export interface ReadStreamOptions {
 // https://github.com/mike-marcacci/fs-capacitor/issues/30
 const processExitProxy = new EventEmitter();
 processExitProxy.setMaxListeners(Infinity);
-process.addListener("exit", () => processExitProxy.emit("exit"));
+process.once("exit", () => processExitProxy.emit("exit"));
 
 export class ReadStream extends Readable {
   private _pos: number = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class WriteStream extends Writable {
   }
 
   _cleanupSync = (): void => {
-    processExitProxy.removeListener("exit", this._cleanupSync);
+    processExitProxy.off("exit", this._cleanupSync);
 
     if (typeof this._fd === "number")
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export class WriteStream extends Writable {
 
         // We avoid removing this until now in case an exit occurs while
         // asyncronously cleaning up.
-        processExitProxy.removeListener("exit", this._cleanupSync);
+        processExitProxy.off("exit", this._cleanupSync);
         callback(unlinkError || closeError || error);
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,9 @@ export interface ReadStreamOptions {
   encoding?: ReadableOptions["encoding"];
 }
 
-// Work around node's MaxListenersExceededWarning for highly concurrent
-// workloads by creating a "proxy" event emitter. See:
+// Use a “proxy” event emitter configured to have an infinite maximum number of
+// listeners to prevent Node.js max listeners exceeded warnings if many
+// `fs-capacitor` `ReadStream` instances are created at the same time. See:
 // https://github.com/mike-marcacci/fs-capacitor/issues/30
 const processExitProxy = new EventEmitter();
 processExitProxy.setMaxListeners(Infinity);

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,16 +241,13 @@ export class WriteStream extends Writable {
     const readStream = new ReadStream(this, options);
     this._readStreams.add(readStream);
 
-    const remove = (): void => {
-      readStream.off("close", remove);
+    readStream.once("close", (): void => {
       this._readStreams.delete(readStream);
 
       if (this._released && this._readStreams.size === 0) {
         this.destroy();
       }
-    };
-
-    readStream.on("close", remove);
+    });
 
     return readStream;
   }


### PR DESCRIPTION
This fixes #30, working around node's MaxListenersExceededWarning by creating a "proxy" event emitter to forward `exit` events.

This is a more concise alternative to #34.