### PR TITLE
drop support for node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: ["10", "12", "14"]
+        node: ["12", "14", "15"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,4 @@
 
 - Upgrade dependencies.
 - **BREAKING:** Drop support for node 13.
+- **BREAKING:** Drop support for node 10.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "browserslist": "node >= 10",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "engines": {
     "node": ">=12"
   },
-  "browserslist": "node >= 10",
+  "browserslist": "node >= 12",
   "devDependencies": {
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",


### PR DESCRIPTION
Node 10 reaches EOL on April 30th, and support will be dropped then.