### PR TITLE
Es module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: ["10", "12", "14"]
+        node: ["12", "14", "15"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,4 @@
 
 - Upgrade dependencies.
 - **BREAKING:** Drop support for node 13.
+- **BREAKING:** Drop support for node 10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,4 @@
 - Upgrade dependencies.
 - **BREAKING:** Drop support for node 13.
 - **BREAKING:** Drop support for node 10.
+- **BREAKING:** Change module type to ES module.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 7       | :white_check_mark: |
 | 6       | :white_check_mark: |
 | < 6     | :x:                |
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "node": ">=12"
   },
   "browserslist": "node >= 12",
+  "ava": {
+    "nodeArguments": [
+      "--experimental-specifier-resolution=node"
+    ]
+  },
   "devDependencies": {
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
@@ -42,10 +47,12 @@
     "lint": "prettier -c '**/*.{json,yml,md,ts}' && eslint src --ext ts",
     "build": "rm -rf dist && tsc",
     "build:development": "rm -rf dist && tsc --watch",
-    "test": "ava --verbose dist/*.test.js",
-    "test:development": "ava --verbose --watch dist/*.test.js",
+    "test": "ava --verbose dist/index.test.js",
+    "test:development": "ava --verbose --watch dist/index.test.js",
     "prepare": "yarn build",
     "prepublishOnly": "yarn install && yarn lint && yarn build && yarn test"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "type": "module",
+  "exports": "./dist/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "browserslist": "node >= 10",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "engines": {
     "node": ">=12"
   },
-  "browserslist": "node >= 10",
+  "browserslist": "node >= 12",
   "devDependencies": {
     "@types/node": "^14.14.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,7 @@
-import fs from "fs";
-import stream from "stream";
-import test from "ava";
-import { ReadAfterDestroyedError, WriteStream } from "./index";
+import { existsSync } from "fs";
 import { Readable } from "stream";
+import { ReadAfterDestroyedError, WriteStream } from "./index";
+import test from "ava";
 
 process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
@@ -40,7 +39,7 @@ function waitForBytesWritten(
 
 test("Data from a complete stream.", async (t) => {
   let data = "";
-  const source = new stream.Readable({
+  const source = new Readable({
     read() {
       // Intentionally not implementing anything here.
     },
@@ -79,7 +78,7 @@ test("Data from a complete stream.", async (t) => {
 
 test("Allows specification of encoding in createReadStream.", async (t) => {
   const data = Buffer.from("1".repeat(10), "utf8");
-  const source = new stream.Readable({
+  const source = new Readable({
     read() {
       // Intentionally not implementing anything here.
     },
@@ -112,7 +111,7 @@ test("Allows specification of encoding in createReadStream.", async (t) => {
 
 test("Allows specification of defaultEncoding in new WriteStream.", async (t) => {
   const data = Buffer.from("1".repeat(10), "utf8");
-  const source = new stream.Readable({
+  const source = new Readable({
     encoding: "base64",
     read() {
       // Intentionally not implementing anything here.
@@ -167,7 +166,7 @@ test("Allows specification of highWaterMark.", async (t) => {
 
 test("Data from an open stream, 1 chunk, no read streams.", async (t) => {
   let data = "";
-  const source = new stream.Readable({
+  const source = new Readable({
     read() {
       // Intentionally not implementing anything here.
     },
@@ -206,7 +205,7 @@ test("Data from an open stream, 1 chunk, no read streams.", async (t) => {
 
 test("Data from an open stream, 1 chunk, 1 read stream.", async (t) => {
   let data = "";
-  const source = new stream.Readable({
+  const source = new Readable({
     read() {
       // Intentionally not implementing anything here.
     },
@@ -331,7 +330,7 @@ test("Destroy without error.", async (t) => {
 function withChunkSize(size: number): void {
   test(`End-to-end with chunk size: ${size}`, async (t) => {
     let data = "";
-    const source = new stream.Readable({
+    const source = new Readable({
       read() {
         // Intentionally not implementing anything here.
       },
@@ -363,7 +362,7 @@ function withChunkSize(size: number): void {
       "capacitor1._path should be a string"
     );
     t.is(typeof fd, "number", "capacitor1._fd should be a number");
-    t.is(fs.existsSync(path), true, "creates a temp file");
+    t.is(existsSync(path), true, "creates a temp file");
 
     // Pipe data to the capacitor.
     source.pipe(capacitor1);
@@ -498,7 +497,7 @@ function withChunkSize(size: number): void {
     t.is(capacitor1["_fd"], null, "should set fd to null");
     t.is(capacitor1.destroyed, true, "should mark capacitor as destroyed");
     t.is(
-      fs.existsSync(capacitor1["_path"] as string),
+      existsSync(capacitor1["_path"] as string),
       false,
       "removes its temp file"
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import crypto from "crypto";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import { randomBytes } from "crypto";
+import { read, open, closeSync, unlinkSync, write, close, unlink } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { Readable, ReadableOptions, Writable, WritableOptions } from "stream";
 
 export class ReadAfterDestroyedError extends Error {}
@@ -37,44 +37,37 @@ export class ReadStream extends Readable {
     // `bytesRead`, and discard the rest. This prevents node from having to zero
     // out the entire allocation first.
     const buf = Buffer.allocUnsafe(n);
-    fs.read(
-      this._writeStream["_fd"],
-      buf,
-      0,
-      n,
-      this._pos,
-      (error, bytesRead) => {
-        if (error) this.destroy(error);
+    read(this._writeStream["_fd"], buf, 0, n, this._pos, (error, bytesRead) => {
+      if (error) this.destroy(error);
 
-        // Push any read bytes into the local stream buffer.
-        if (bytesRead) {
-          this._pos += bytesRead;
-          this.push(buf.slice(0, bytesRead));
-          return;
-        }
-
-        // If there were no more bytes to read and the write stream is finished,
-        // than this stream has reached the end.
-        if (
-          ((this._writeStream as any) as {
-            _writableState: { finished: boolean };
-          })._writableState.finished
-        ) {
-          this.push(null);
-          return;
-        }
-
-        // Otherwise, wait for the write stream to add more data or finish.
-        const retry = (): void => {
-          this._writeStream.removeListener("finish", retry);
-          this._writeStream.removeListener("write", retry);
-          this._read(n);
-        };
-
-        this._writeStream.addListener("finish", retry);
-        this._writeStream.addListener("write", retry);
+      // Push any read bytes into the local stream buffer.
+      if (bytesRead) {
+        this._pos += bytesRead;
+        this.push(buf.slice(0, bytesRead));
+        return;
       }
-    );
+
+      // If there were no more bytes to read and the write stream is finished,
+      // than this stream has reached the end.
+      if (
+        ((this._writeStream as any) as {
+          _writableState: { finished: boolean };
+        })._writableState.finished
+      ) {
+        this.push(null);
+        return;
+      }
+
+      // Otherwise, wait for the write stream to add more data or finish.
+      const retry = (): void => {
+        this._writeStream.removeListener("finish", retry);
+        this._writeStream.removeListener("write", retry);
+        this._read(n);
+      };
+
+      this._writeStream.addListener("finish", retry);
+      this._writeStream.addListener("write", retry);
+    });
   }
 }
 
@@ -98,19 +91,16 @@ export class WriteStream extends Writable {
     });
 
     // Generate a random filename.
-    crypto.randomBytes(16, (error, buffer) => {
+    randomBytes(16, (error, buffer) => {
       if (error) {
         this.destroy(error);
         return;
       }
 
-      this._path = path.join(
-        os.tmpdir(),
-        `capacitor-${buffer.toString("hex")}.tmp`
-      );
+      this._path = join(tmpdir(), `capacitor-${buffer.toString("hex")}.tmp`);
 
       // Create a file in the OS's temporary files directory.
-      fs.open(this._path, "wx+", 0o600, (error, fd) => {
+      open(this._path, "wx+", 0o600, (error, fd) => {
         if (error) {
           this.destroy(error);
           return;
@@ -130,14 +120,16 @@ export class WriteStream extends Writable {
 
     if (typeof this._fd === "number")
       try {
-        fs.closeSync(this._fd);
+        closeSync(this._fd);
       } catch (error) {
         // An error here probably means the fd was already closed, but we can
         // still try to unlink the file.
       }
 
     try {
-      if (this._path) fs.unlinkSync(this._path);
+      if (this._path !== null) {
+        unlinkSync(this._path);
+      }
     } catch (error) {
       // If we are unable to unlink the file, the operating system will clean
       // up on next restart, since we use store thes in `os.tmpdir()`
@@ -162,7 +154,7 @@ export class WriteStream extends Writable {
       return;
     }
 
-    fs.write(this._fd, chunk, 0, chunk.length, this._pos, (error) => {
+    write(this._fd, chunk, 0, chunk.length, this._pos, (error) => {
       if (error) {
         callback(error);
         return;
@@ -198,10 +190,10 @@ export class WriteStream extends Writable {
     }
 
     // Close the file descriptor.
-    fs.close(fd, (closeError) => {
+    close(fd, (closeError) => {
       // An error here probably means the fd was already closed, but we can
       // still try to unlink the file.
-      fs.unlink(path, (unlinkError) => {
+      unlink(path, (unlinkError) => {
         // If we are unable to unlink the file, the operating system will
         // clean up on next restart, since we use store thes in `os.tmpdir()`
         this._fd = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,15 @@
   "compilerOptions": {
     "lib": ["es2018"],
     "target": "es2018",
-    "module": "commonjs",
+    "module": "es2020",
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "./dist",
+    "moduleResolution": "node",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "sourceMap": true
   },
   "include": ["./src/**/*"]


### PR DESCRIPTION
Come the end of April, node 10 will be EOL and the entire ecosystem will begin transitioning to ES modules. This will be part of a version 7 release, but I can continue supporting version 6 (for commonjs-only projects) for some time after.

This is the perfect "leaf" type project (with no dependencies of its own) that needs to make this change promptly to help with this transition. Accordingly, I am interested in merging this into master once it's ready, and will publish it to NPM on May 1.

@jaydenseric you're MUCH more proficient and up-to-date with the status of ESM in node. This should be exceedingly straightforward, but I would definitely appreciate a quick look if you have a chance (especially anything I may have omitted from the package.json).