### PR TITLE
Include .d.ts and .map files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "clone"
   ],
   "files": [
-    "dist/index.js"
+    "dist/index.d.ts",
+    "dist/index.js",
+    "dist/index.js.map"
   ],
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
This fixed an issue raised in #53, where the published npm package is missing the the TypeScript definition file, despite it being built.