### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^16.11.1",
-    "@typescript-eslint/eslint-plugin": "^5.1.0",
-    "@typescript-eslint/parser": "^5.1.0",
-    "ava": "^3.15.0",
-    "eslint": "^8.0.1",
+    "@types/node": "^17.0.12",
+    "@typescript-eslint/eslint-plugin": "^5.10.1",
+    "@typescript-eslint/parser": "^5.10.1",
+    "ava": "^4.0.1",
+    "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "nodemon": "^2.0.14",
-    "prettier": "^2.4.1",
-    "typescript": "^4.4.4"
+    "nodemon": "^2.0.15",
+    "prettier": "^2.5.1",
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "format": "prettier --list-different --write '**/*.{json,yml,md,ts}'",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -298,12 +298,12 @@ test("Destroy with error.", async (t) => {
     true,
     "should mark attached read streams as destroyed"
   );
-  t.is(
+  t.is<undefined | Error, Error>(
     capacitor2Stream2Error,
     error,
     "should emit the original error on read stream"
   );
-  t.is(
+  t.is<undefined | Error, Error>(
     capacitor2Error,
     error,
     "should emit the original error on write stream"


### PR DESCRIPTION
This updates deps, replacing #73 and #70, and fixing type inferences from the newer version of Ava.