### PR TITLE
Check if read stream has consumed all the written bytes before ending

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ export class ReadStream extends Readable {
           }
         )._writableState.finished
       ) {
-        this.push(null);
+        // Check if we have consumed the whole file up to where
+        // the write stream has written before ending the stream
+        if (this._pos < (this._writeStream as any as { _pos: number })._pos)
+          this._read(n);
+        else this.push(null);
         return;
       }
 


### PR DESCRIPTION
This fixes #75 by ensuring that the read stream's position is the same as the write stream's position before ending the stream.