### PR TITLE
Drop support for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: ["12", "14", "16", "17"]
+        node: ["14", "16", "18"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 - Upgrade dependencies.
 - Update option types to match changes in @types/node.
 
-### 7.0.0
+## 7.0.0
 
 - Upgrade dependencies.
 - Prevent Node.js max listeners exceeded warnings if many `fs-capacitor` `ReadStream` instances are created at the same time, fixing [#30](https://github.com/mike-marcacci/fs-capacitor/issues/30) via [#42](https://github.com/mike-marcacci/fs-capacitor/pull/42).
@@ -107,3 +107,4 @@
 ### next
 
 - Upgrade development dependencies.
+- **BREAKING:** Drop support for node 12.

--- a/package.json
+++ b/package.json
@@ -41,16 +41,16 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^17.0.12",
-    "@typescript-eslint/eslint-plugin": "^5.10.1",
-    "@typescript-eslint/parser": "^5.10.1",
-    "ava": "^4.0.1",
-    "eslint": "^8.7.0",
-    "eslint-config-prettier": "^8.3.0",
+    "@types/node": "^17.0.41",
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
+    "ava": "^4.3.0",
+    "eslint": "^8.17.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "nodemon": "^2.0.15",
-    "prettier": "^2.5.1",
-    "typescript": "^4.5.5"
+    "nodemon": "^2.0.16",
+    "prettier": "^2.6.2",
+    "typescript": "^4.7.3"
   },
   "scripts": {
     "format": "prettier --list-different --write '**/*.{json,yml,md,ts}'",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,13 @@
   ],
   "main": "dist/index.js",
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    "node": "^14.17.0 || >=16.0.0"
   },
   "browserslist": {
     "production": [
-      "node >= 12"
+      "node >= 14"
     ],
     "development": [
-      "node ^12.22.0",
       "node ^14.17.0",
       "node >=16.0.0"
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export class ReadStream extends Readable {
       }
 
       // If there were no more bytes to read and the write stream is finished,
-      // than this stream has reached the end.
+      // then this stream has reached the end.
       if (
         (
           this._writeStream as any as {


### PR DESCRIPTION
Node 18 is now the current LTS version, and 12 is no longer supported. This makes no runtime changes, but:

- Drops support for node 12 in package.json
- Drops support for node 12 in the GitHub action, while adding node 18
- Upgrades development dependencies
- Fixes a trivial typo in comment
